### PR TITLE
Add ability to use custom references resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.3.0
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+ENV BUNDLE_PATH /bundle
+RUN bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     hana (1.2.1)
+    minitest (5.9.0)
     rake (10.1.0)
 
 PLATFORMS
@@ -15,4 +16,8 @@ PLATFORMS
 
 DEPENDENCIES
   json-ref!
+  minitest
   rake
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -24,8 +24,26 @@ Or install it yourself as:
 ```ruby
 origin_doc = { 'title' => 'foobar', 'ref_title' => { '$ref' => '#/title' } }
 JSONRef.new(origin_doc).expand
-# => 
+# =>
 { 'title' => 'foobar', 'ref_title' => 'foobar' }
+```
+
+It's also possible to resolve the `$ref` manually. You can specify a block and
+return with *replace* value from the block.
+
+```yaml
+# other.yaml
+author: "John Smith"
+```
+
+```ruby
+origin_doc = { "title" => "foobar", "meta" => { "$ref" => "other.yaml" } }
+JSONRef.new(origin_doc).expand do |path, ref|
+  # path => "meta"
+  # ref => "other.yml"
+  YAML.load(File.read(ref))
+end
+# => { "title" => "foobar", "meta" => { "author" => "John Smith" } }
 ```
 
 ## Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: bundle exec rake
+    volumes:
+      - .:/usr/src/app
+    volumes_from:
+      - bundle
+
+  bundle:
+    image: busybox
+    volumes:
+      - /bundle

--- a/json-ref.gemspec
+++ b/json-ref.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'json-ref'
+require 'json_ref/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "json-ref"
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
   spec.add_dependency "hana"
 end

--- a/lib/json-ref.rb
+++ b/lib/json-ref.rb
@@ -1,9 +1,8 @@
 require "json"
 require "hana"
+require 'json_ref/version'
 
 class JSONRef
-  VERSION = "0.2.1"
-  
   def initialize(document)
     @document = document
     @refs = []

--- a/lib/json_ref/version.rb
+++ b/lib/json_ref/version.rb
@@ -1,0 +1,3 @@
+class JSONRef
+  VERSION = "0.2.1"
+end

--- a/test/fixtures/file.yaml
+++ b/test/fixtures/file.yaml
@@ -1,0 +1,2 @@
+title: "My PDF"
+path: "/path/to/my.pdf"

--- a/test/test_json-ref.rb
+++ b/test/test_json-ref.rb
@@ -49,4 +49,15 @@ class TestJSONRef < MiniTest::Unit::TestCase
 
     assert_equal result_doc, JSONRef.new(origin_doc).expand
   end
+
+  def test_custom_ref_resolution
+    require 'yaml'
+    origin_doc = { "file" => { "$ref" => "test/fixtures/file.yaml" } }
+    result_doc = { "file" => { "title" => "My PDF", "path" => "/path/to/my.pdf" } }
+
+    expected_doc = JSONRef.new(origin_doc).expand do |path, ref|
+      YAML.load(File.read(ref))
+    end
+    assert_equal result_doc, expected_doc
+  end
 end


### PR DESCRIPTION
I would like to use custom reference resolution.
You can specify a block and return with the _replace_ value from the block.

``` yaml
# other.yaml
author: "John Smith"
```

``` ruby
origin_doc = { "title" => "foobar", "meta" => { "$ref" => "other.yaml" } }
JSONRef.new(origin_doc).expand do |path, ref|
  # path => "meta"
  # ref => "other.yml"
  YAML.load(File.read(ref))
end
# => { "title" => "foobar", "meta" => { "author" => "John Smith" } }
```
